### PR TITLE
Fix imports from assert-json-diff crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "httpmock"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Alexander Liesenfeld <alexander.liesenfeld@outlook.com>"]
 edition = "2018"
 description = "an HTTP mock server library for your tests"
@@ -21,7 +21,7 @@ hyper = "0.12.35"
 tokio = "0.1.22"
 log = "0.4.8"
 qstring = "0.7.2"
-assert-json-diff = "1.0.1"
+assert-json-diff = "1.0.3"
 httpmock-macros = { path = "./lib/macros", version = "0.2.0" }
 
 structopt = { version = "0.3.8", optional = true }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3,7 +3,7 @@ use crate::server::data::{
     RequestRequirements,
 };
 use crate::server::util::{StringTreeMapExtension, TreeMapExtension};
-use assert_json_diff::{assert_json_no_panic, Actual, Comparison, Expected};
+use assert_json_diff::{assert_json_eq_no_panic, assert_json_include_no_panic};
 use serde_json::Value;
 use std::str::FromStr;
 
@@ -288,11 +288,8 @@ fn match_json(req: &Option<String>, mock: &Value, exact: bool) -> bool {
 
             // Compare JSON values
             let result = match exact {
-                true => assert_json_no_panic(Comparison::Exact(req_value, mock.clone())),
-                false => assert_json_no_panic(Comparison::Include(
-                    Actual::from(req_value),
-                    Expected::from(mock.clone()),
-                )),
+                true => assert_json_eq_no_panic(&req_value, mock),
+                false => assert_json_include_no_panic(&req_value, mock),
             };
 
             // Log and return the comparison result


### PR DESCRIPTION
It seems that the interface of said crate changed at some point. The
imported types Actual, Comparison, and Expected do no longer exist in
the crate and assert_json_no_panic is a private function now. Instead
this patch uses the assert_json_{eq, include}_no_panic functions that
are now available in assert_json_diff.

It also updates the assert_json_diff dependency to version 1.0.3, which is
the first version to provide said functions.