### PR TITLE
Improve httpmock's standalone capabilities

### DIFF
--- a/src/server/data.rs
+++ b/src/server/data.rs
@@ -254,7 +254,7 @@ impl ApplicationState {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ActiveMock {
     pub id: usize,
     pub call_counter: usize,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -6,6 +6,7 @@ use crate::server::util::{StringTreeMapExtension, TreeMapExtension};
 use assert_json_diff::{assert_json_eq_no_panic, assert_json_include_no_panic};
 use serde_json::Value;
 use std::str::FromStr;
+use std::collections::BTreeMap;
 
 /// Contains HTTP methods which cannot have a body.
 const NON_BODY_METHODS: &'static [&str] = &["GET", "HEAD", "DELETE"];
@@ -38,6 +39,16 @@ pub fn read_one(state: &ApplicationState, id: usize) -> Result<Option<ActiveMock
             Some(found) => Ok(Some(found.clone())),
             None => Ok(None),
         };
+    }
+}
+
+/// Reads exactly one mock object.
+pub fn read_all(state: &ApplicationState) -> Result<BTreeMap<usize, ActiveMock>, String> {
+    {
+        let mocks = state.mocks.read().unwrap();
+        let result = mocks.clone();
+        log::debug!("Showing all mocks {:?}", result);
+        return Ok(result)
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -221,6 +221,7 @@ fn route_request(
 
     if MOCKS_PATH.is_match(&request_header.path) {
         match request_header.method.as_str() {
+            "GET" => return routes::read_all(state),
             "POST" => return routes::add(state, body),
             "DELETE" => return routes::delete_all(state),
             _ => {}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -284,7 +284,7 @@ fn error_response(body: String) -> HyperResponse<Body> {
 
 lazy_static! {
     static ref MOCK_PATH: Regex = Regex::new(r"/__mocks/([0-9]+)$").unwrap();
-    static ref MOCKS_PATH: Regex = Regex::new(r"/__mocks$").unwrap();
+    static ref MOCKS_PATH: Regex = Regex::new(r"/__mocks(/)?$").unwrap();
     static ref STATE: ApplicationState = ApplicationState::new();
 }
 

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -57,6 +57,15 @@ pub(crate) fn read_one(state: &ApplicationState, id: usize) -> Result<ServerResp
     };
 }
 
+/// This route is responsible for returning all mocks
+pub(crate) fn read_all(state: &ApplicationState) -> Result<ServerResponse, String> {
+    let handler_result = handlers::read_all(state);
+    return match handler_result {
+        Err(e) => create_json_response(500, None, ErrorResponse { message: e.clone() }),
+        Ok(mocks) => create_json_response(200, None, mocks),
+    };
+}
+
 /// This route is responsible for finding a mock that matches the current request and serve a
 /// response according to the mock specification
 pub(crate) fn serve(


### PR DESCRIPTION
This PR does a couple of things:

- Allow for keeping mocks after runs by setting the `HTTPMOCK_KEEP_MOCKS` variable
- Allow for serving all existing mocks by accessing `__mocks/`