### PR TITLE
Small docker image size. Only requires 84MB instead of almost 2GB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM rust:latest
-
+FROM rust:1.40 as builder
 WORKDIR /usr/src/httpmock
 COPY . .
-
 RUN cargo install --features="standalone" --path .
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/httpmock /usr/local/bin/httpmock
 
 EXPOSE 5000
 
 ENV RUST_LOG httpmock=info
-
 ENTRYPOINT httpmock --expose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM rust:1.40 as builder
+# ================================================================================
+# Builder
+# ================================================================================
+FROM rust:latest as builder
 WORKDIR /usr/src/httpmock
 COPY . .
 RUN cargo install --features="standalone" --path .
 
+# ================================================================================
+# Runner
+# ================================================================================
 FROM debian:buster-slim
 RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/httpmock /usr/local/bin/httpmock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================================================================
 # Builder
 # ================================================================================
-FROM rust:latest as builder
+FROM rust:1.40 as builder
 WORKDIR /usr/src/httpmock
 COPY . .
 RUN cargo install --features="standalone" --path .


### PR DESCRIPTION
Made the built docker image smaller.