### PR TITLE
feat: Make cookie handling optional via cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ async-trait = "0.1"
 async-object-pool = "0.1"
 crossbeam-utils = "0.8"
 futures-util = "0.3"
-basic-cookies = "0.1"
 similar = "2.1.0"
 levenshtein = "1.0"
 form_urlencoded = "1.0"
 
+basic-cookies = { version = "0.1", optional = true }
 colored = { version = "2.0", optional = true }
 clap = { version = "3.0.0-rc.7", features = ["derive", "env"], optional = true }
 env_logger = { version = "0.9", optional = true }
@@ -51,8 +51,10 @@ colored = "2.0"
 ureq = "2.3"
 
 [features]
+default = ["cookies"]
 standalone = ["clap", "env_logger", "serde_yaml"]
 color = ["colored"]
+cookies = ["basic-cookies"]
 
 [[bin]]
 name = "httpmock"

--- a/src/api/mock.rs
+++ b/src/api/mock.rs
@@ -556,6 +556,7 @@ mod test {
     };
 
     #[test]
+    #[cfg(not(feature = "color"))]
     #[should_panic(expected = "1 : This is a title\n\
     ------------------------------------------------------------------------------------------\n\
     Expected:	[equals]		/toast\n\

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -667,6 +667,9 @@ impl When {
     /// * `name` - The cookie name.
     /// * `value` - The expected cookie value.
     ///
+    /// > Note: This function is only available when the `cookies` feature is enabled.
+    /// > It is enabled by default.
+    ///
     /// # Example
     /// ```
     /// use httpmock::prelude::*;
@@ -706,6 +709,9 @@ impl When {
     /// **Attention**: Cookie names are **case-sensitive**.
     ///
     /// * `name` - The cookie name
+    ///
+    /// > Note: This function is only available when the `cookies` feature is enabled.
+    /// > It is enabled by default.
     ///
     /// # Example
     /// ```

--- a/src/server/matchers/mod.rs
+++ b/src/server/matchers/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
+#[cfg(feature = "cookies")]
 use basic_cookies::Cookie;
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
@@ -45,6 +46,7 @@ pub trait Matcher {
 // *************************************************************************************************
 // Helper functions
 // *************************************************************************************************
+#[cfg(feature = "cookies")]
 pub(crate) fn parse_cookies(req: &HttpMockRequest) -> Result<Vec<(String, String)>, String> {
     let parsing_result = req.headers.as_ref().map_or(None, |request_headers| {
         request_headers

--- a/src/server/matchers/targets.rs
+++ b/src/server/matchers/targets.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeMap;
 use serde_json::Value;
 
 use crate::common::data::HttpMockRequest;
-use crate::server::matchers::parse_cookies;
-use crate::server::matchers::sources::ValueRefSource;
+use crate::server::matchers;
 
 pub(crate) trait ValueTarget<T> {
     fn parse_from_request(&self, req: &HttpMockRequest) -> Option<T>;
@@ -69,17 +68,20 @@ impl ValueTarget<Value> for JSONBodyTarget {
 // *************************************************************************************
 // CookieTarget
 // *************************************************************************************
+#[cfg(feature = "cookies")]
 pub(crate) struct CookieTarget {}
 
+#[cfg(feature = "cookies")]
 impl CookieTarget {
     pub fn new() -> Self {
         Self {}
     }
 }
 
+#[cfg(feature = "cookies")]
 impl MultiValueTarget<String, String> for CookieTarget {
     fn parse_from_request(&self, req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
-        let req_cookies = match parse_cookies(req) {
+        let req_cookies = match matchers::parse_cookies(req) {
             Ok(v) => v,
             Err(err) => {
                 log::info!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,9 +37,11 @@ use crate::server::matchers::sources::{
     StringPathSource, XWWWFormUrlencodedSource,
 };
 use crate::server::matchers::targets::{
-    CookieTarget, FullRequestTarget, HeaderTarget, MethodTarget, PathTarget, QueryParameterTarget,
+    FullRequestTarget, HeaderTarget, MethodTarget, PathTarget, QueryParameterTarget,
     XWWWFormUrlEncodedBodyTarget,
 };
+#[cfg(feature = "cookies")]
+use crate::server::matchers::targets::CookieTarget;
 use crate::server::matchers::Matcher;
 use crate::server::web::routes;
 use futures_util::task::Spawn;
@@ -144,6 +146,7 @@ impl MockServerState {
                     weight: 1,
                 }),
                 // Cookie exact
+                #[cfg(feature = "cookies")]
                 Box::new(MultiValueMatcher {
                     entity_name: "cookie",
                     key_comparator: Box::new(StringExactMatchComparator::new(true)),
@@ -157,6 +160,7 @@ impl MockServerState {
                     weight: 1,
                 }),
                 // Cookie exists
+                #[cfg(feature = "cookies")]
                 Box::new(MultiValueMatcher {
                     entity_name: "cookie",
                     key_comparator: Box::new(StringExactMatchComparator::new(true)),

--- a/src/server/web/handlers.rs
+++ b/src/server/web/handlers.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
+#[cfg(feature = "cookies")]
 use basic_cookies::Cookie;
 use serde_json::Value;
 

--- a/tests/examples/headers_tests.rs
+++ b/tests/examples/headers_tests.rs
@@ -24,4 +24,5 @@ fn headers_test() {
     // Assert
     m.assert();
     assert_eq!(response.status(), 201);
+    assert_eq!(response.headers().get("Content-Length").unwrap().to_str().unwrap(), "0");
 }


### PR DESCRIPTION
Cookie handling includes a dependency that uses the excellent lalrpop parsing library. Unfortunately, lalrpop is also fairly slow to compile. For projects that don't need cookie handling, it's wasted compile time. Making cookie handling in this crate optional helps speed up downstream compile times.

I tested this using [`cargo-hack`](https://crates.io/crates/cargo-hack):

```shell
$ cargo-hack --feature-powerset test
```