### PR TITLE
Fix typos and markdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,108 +1,129 @@
+# Changelog
+
 ## Version 0.6.6
-- Extended some API methods to allow for more type flexibility (see https://github.com/alexliesenfeld/httpmock/issues/58). Thanks to [@95th](https://github.com/95th) for providing the PR!
-- Fixed parsing query parameter values that contain `+` to represent space (see https://github.com/alexliesenfeld/httpmock/issues/56). Thanks to [@95th](https://github.com/95th) for providing the PR!
-- Added a new Cargo feature `cookie` to shorten compile time (see https://github.com/alexliesenfeld/httpmock/pull/63). Thanks to [mythmon](https://github.com/mythmon) for providing this PR!
+
+- Extended some API methods to allow for more type flexibility (see <https://github.com/alexliesenfeld/httpmock/issues/58>). Thanks to [@95th](https://github.com/95th) for providing the PR!
+- Fixed parsing query parameter values that contain `+` to represent space (see <https://github.com/alexliesenfeld/httpmock/issues/56>). Thanks to [@95th](https://github.com/95th) for providing the PR!
+- Added a new Cargo feature `cookie` to shorten compile time (see <https://github.com/alexliesenfeld/httpmock/pull/63>). Thanks to [mythmon](https://github.com/mythmon) for providing this PR!
 
 ## Version 0.6.5
-- Fixes a race condition that could occur when deleting mocks from the mock server (see https://github.com/alexliesenfeld/httpmock/issues/53).
-- Replaced internal diff library (switched from `difference` to `similar`, see https://github.com/alexliesenfeld/httpmock/pull/55). 
+
+- Fixes a race condition that could occur when deleting mocks from the mock server (see <https://github.com/alexliesenfeld/httpmock/issues/53>).
+- Replaced internal diff library (switched from `difference` to `similar`, see <https://github.com/alexliesenfeld/httpmock/pull/55>).
 
 ## Version 0.6.4
+
 - Fixed minimum Rust version in README (raised from 1.47 to 1.54, see release 0.6.3 for more information).
 
 ## Version 0.6.3
+
 - This is a maintenance release that updates all dependencies to the most recent version.
 - Bumped minimum Rust version to 1.54 due to transitive dependency.
 
 ## Version 0.6.2
+
 - A bug was fixed that has unexported the [When](https://docs.rs/httpmock/0.5.8/httpmock/struct.When.html) and
   [Then](https://docs.rs/httpmock/0.5.8/httpmock/struct.When.html) structures. Both types are now exported again.
-  Please refer to https://github.com/alexliesenfeld/httpmock/issues/47 for more info.
-  
+  Please refer to <https://github.com/alexliesenfeld/httpmock/issues/47> for more info.
+
 ## Version 0.6.1
+
 - This is a maintenance release that updates all dependencies to the most recent version.
 
 ## Version 0.6.0
+
 ### General
-- Old [Mock](https://docs.rs/httpmock/0.4.5/httpmock/struct.Mock.html) structure based API was deprecated 
-  starting from version 0.5.0 and was removed with this version. Please switch to the new API based on the 
-  [When](https://docs.rs/httpmock/0.5.8/httpmock/struct.When.html) / 
+
+- Old [Mock](https://docs.rs/httpmock/0.4.5/httpmock/struct.Mock.html) structure based API was deprecated
+  starting from version 0.5.0 and was removed with this version. Please switch to the new API based on the
+  [When](https://docs.rs/httpmock/0.5.8/httpmock/struct.When.html) /
   [Then](https://docs.rs/httpmock/0.5.8/httpmock/struct.When.html) structures.
-- The two methods `MockRef::times_called` and `MockRef::times_called_async` were deprecated since version 0.5.0 and 
+- The two methods `MockRef::times_called` and `MockRef::times_called_async` were deprecated since version 0.5.0 and
   have now been removed.
-- A [prelude module](https://github.com/alexliesenfeld/httpmock#getting-started) was added to shorten imports 
+- A [prelude module](https://github.com/alexliesenfeld/httpmock#getting-started) was added to shorten imports
   that are usually required when using `httpmock` in tests.
-- The struct `MockRef` has been renamed to `Mock`. 
+- The struct `MockRef` has been renamed to `Mock`.
 - Trait `MockRefExt` has been renamed to `MockExt`.
 - Added support for x-www-form-urlencoded request bodies.
 
 ### Standalone Mock Server
+
 - Standalone server now has a request history limit that can be adjusted.
 - All standalone servers parameters now have an environment variable fallback.
-- Standalone servers `exposed` and `disable_access_log` parameters were changed, so that they now require a value 
-  in addition to the flag itself (this is due to a limitation of `structopt`/`clap`): 
+- Standalone servers `exposed` and `disable_access_log` parameters were changed, so that they now require a value
+  in addition to the flag itself (this is due to a limitation of `structopt`/`clap`):
   Before: `httpmock --expose`, Now: `httpmock --expose true`.
 
 ## Version 0.5.8
-- A bug has been fixed that prevented to use the mock server for requests containing a `multipart/form-data` 
+
+- A bug has been fixed that prevented to use the mock server for requests containing a `multipart/form-data`
   request body with binary data.
 
 ## Version 0.5.7
+
 - Added static mock support based on YAML files for standalone mode.
 - Dockerfile Rust version has been fixed.
 - Documentation on query parameters has been enhanced.
 - Bumped minimum Rust version to 1.46 due to transitive dependency.
 
-## Version 0.5.6 
+## Version 0.5.6
+
 - A bug has been fixed that caused false positive warnings in the log output.
 - Updated all dependencies to the most recent versions.
 - Assertion error messages (`MockRef::assert` and `MockRef::assert_hits`) now contain more details.
 
 ## Version 0.5.5
-- A bug has been fixed that prevented to use a request body in DELETE requests.  
+
+- A bug has been fixed that prevented to use a request body in DELETE requests.
 
 ## Version 0.5.4
-- A new extension trait `MockRefExt` was added that extends the `MockRef` structure with additional but usually 
-not required functionality.  
+
+- A new extension trait `MockRefExt` was added that extends the `MockRef` structure with additional but usually
+not required functionality.
 
 ## Version 0.5.3
+
 - This is a maintenance release that updates all dependencies to the most recent version.
 - This release bumps the minimal Rust version from 1.43+ to 1.45+.
 
 ## Version 0.5.2
+
 - Updated dependencies to newest version.
 - Removed dependency version fixation from v0.5.1.
 - `Mock::return_body_from_file` and `Then::body_from_file` now accept absolute and relative file paths.
- 
+
 ## Version 0.5.1
+
 - Updated dependency to futures-util to fix compile errors.
 - Fixed all dependency version numbers to avoid future problems with new dependency version releases.
 
 ## Version 0.5.0
+
 - ❌ _**Breaking Change**_: Function `Mock::expect_json_body` was renamed to `expect_json_body_obj`.
 - ❌ _**Breaking Change**_: Function `Mock::return_json_body` was renamed to `return_json_body_obj`.
-- 🚀 _**Attention**: A new API for mock definition was added. The old API is still available and functional, 
+- 🚀 _**Attention**: A new API for mock definition was added. The old API is still available and functional,
 but is deprecated from now on. Please consider switching to the new API._
-- 🚀 **Attention**: The following new assertion functions have been added that will provide you smart and helpful 
+- 🚀 **Attention**: The following new assertion functions have been added that will provide you smart and helpful
 error output to support debugging:
-    - `MockRef::assert`
-    - `MockRef::assert_hits`
-    - `MockRef::assert_async`
-    - `MockRef::assert_hits_async`
+  - `MockRef::assert`
+  - `MockRef::assert_hits`
+  - `MockRef::assert_async`
+  - `MockRef::assert_hits_async`
 - The two methods `MockRef::times_called` and `MockRef::times_called_async` are now deprecated. Consider using
 `MockRef::hits` and `MockRef::hits_async`.
 - The two methods `Mock::return_body` and `Then::body` now accept binary content.
 - The following new methods accept a `serde_json::Value`:
-    - `Mock::expect_json_body`
-    - `Mock::return_json_body`
-    - `When::json_body`
-    - `Then::json_body`
+  - `Mock::expect_json_body`
+  - `Mock::return_json_body`
+  - `When::json_body`
+  - `Then::json_body`
 - 🔥 Improved documentation (**a lot!**).
-- 👏 Debug log output is now pretty printed! 
+- 👏 Debug log output is now pretty printed!
 - 🍪 Cookie matching support.
 - Support for convenient temporary and permanent redirect.
 - The log level of some log messages was changed from `debug` to `trace` to make debugging easier.
 
 ## Version 0.4.5
+
 - Improved documentation.
 - Added a new function `base_url` to the `MockServer` structure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV HTTPMOCK_PORT 5000
 # Container internal directory path that contains file bases mock specs (YAML-fies).
 # ENV HTTPMOCK_MOCK_FILES_DIR /mocks
 
-# The existance of this environment variable (even if value is empty) is considered "true"/"disabled".
+# The existence of this environment variable (even if value is empty) is considered "true"/"disabled".
 # ENV HTTPMOCK_DISABLE_ACCESS_LOG true
 
 # Request history limit.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">HTTP mocking library for Rust.</p>
 <div align="center">
-    
+
 [![Build Status](https://dev.azure.com/alexliesenfeld/httpmock/_apis/build/status/alexliesenfeld.httpmock?branchName=master)](https://dev.azure.com/alexliesenfeld/httpmock/_build/latest?definitionId=2&branchName=master)
 [![codecov](https://codecov.io/gh/alexliesenfeld/httpmock/branch/master/graph/badge.svg)](https://codecov.io/gh/alexliesenfeld/httpmock)
 [![crates.io](https://img.shields.io/crates/d/httpmock.svg)](https://crates.io/crates/httpmock)
@@ -39,13 +39,16 @@
 * Support for [mock specification based on YAML files](https://github.com/alexliesenfeld/httpmock/tree/master#file-based-mock-specification).
 
 ## Getting Started
+
 Add `httpmock` to `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
 httpmock = "0.6"
 ```
+
 You can then use `httpmock` as follows:
+
 ```rust
 use httpmock::prelude::*;
 
@@ -72,40 +75,45 @@ hello_mock.assert();
 assert_eq!(response.status(), 200);
 ```
 
-The above example will spin up a lightweight HTTP mock server and configure it to respond to all `GET` requests 
-to path `/translate` with query parameter `word=hello`. The corresponding HTTP response will contain the text body 
+The above example will spin up a lightweight HTTP mock server and configure it to respond to all `GET` requests
+to path `/translate` with query parameter `word=hello`. The corresponding HTTP response will contain the text body
 `Привет`.
 
 # Usage
+
 See the [reference docs](https://docs.rs/httpmock/) for detailed API documentation.
 
 ## Examples
-You can find examples in the 
-[`httpmock` test directory](https://github.com/alexliesenfeld/httpmock/blob/master/tests/). 
-The [reference docs](https://docs.rs/httpmock/) also contain _**a lot**_ of examples. There is an [online tutorial](https://alexliesenfeld.com/mocking-http-services-in-rust) as well. 
+
+You can find examples in the
+[`httpmock` test directory](https://github.com/alexliesenfeld/httpmock/blob/master/tests/).
+The [reference docs](https://docs.rs/httpmock/) also contain _**a lot**_ of examples. There is an [online tutorial](https://alexliesenfeld.com/mocking-http-services-in-rust) as well.
 
 ## Standalone Mock Server
-You can use `httpmock` to run a standalone mock server that is executed in a separate process. There is a 
+
+You can use `httpmock` to run a standalone mock server that is executed in a separate process. There is a
 [Docker image](https://hub.docker.com/r/alexliesenfeld/httpmock) available at Dockerhub to get started quickly.
 
-The standalone mode allows you to mock HTTP based APIs for many API clients, not only the ones 
-inside your Rust tests, but also completely different programs running on remote hosts. 
-This is especially useful if you want to use `httpmock` in system or end-to-end tests that require mocked services 
+The standalone mode allows you to mock HTTP based APIs for many API clients, not only the ones
+inside your Rust tests, but also completely different programs running on remote hosts.
+This is especially useful if you want to use `httpmock` in system or end-to-end tests that require mocked services
 (such as REST APIs, data stores, authentication providers, etc.).
 
 Please refer to [the docs](https://docs.rs/httpmock/0.5.8/httpmock/#standalone-mode) for more information
 
 ### File Based Mock Specification
-For convenience, the standalone mode also allows you to use YAML files for mock specification, so you do not need to
-use Rust or any other programming language at all. The mock specification file schema is very similar to the `httpmock` 
-Rust API, so it's easy to jump between the two. Please find an example mock specification file 
-[here](https://github.com/alexliesenfeld/httpmock/blob/master/tests/resources/static_yaml_mock.yaml). 
 
-Please refer to [the docs](https://github.com/alexliesenfeld/httpmock/blob/master/src/lib.rs#L185-L201) 
+For convenience, the standalone mode also allows you to use YAML files for mock specification, so you do not need to
+use Rust or any other programming language at all. The mock specification file schema is very similar to the `httpmock`
+Rust API, so it's easy to jump between the two. Please find an example mock specification file
+[here](https://github.com/alexliesenfeld/httpmock/blob/master/tests/resources/static_yaml_mock.yaml).
+
+Please refer to [the docs](https://github.com/alexliesenfeld/httpmock/blob/master/src/lib.rs#L185-L201)
 for more information.
 
 ## License
+
 `httpmock` is free software: you can redistribute it and/or modify it under the terms of the MIT Public License.
- 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the MIT Public License for more details.

--- a/src/api/mock.rs
+++ b/src/api/mock.rs
@@ -390,7 +390,7 @@ pub trait MockExt<'a> {
     /// mock on a [MockServer](struct.MockServer.html). This functionality is usually not required.
     /// You can use it if for you need to recreate [Mock](struct.Mock.html) instances
     ///.
-    /// * `id` - The ID of the existing mock ot the [MockServer](struct.MockServer.html).
+    /// * `id` - The ID of the existing mock to the [MockServer](struct.MockServer.html).
     /// * `mock_server` - The [MockServer](struct.MockServer.html) to which the
     /// [Mock](struct.Mock.html) instance will reference.
     ///

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -571,7 +571,7 @@ impl When {
     ///     then.status(200);
     /// });
     /// ```
-    /// Please note that the JSON partial contains the full object hierachy, i.e. it needs to start
+    /// Please note that the JSON partial contains the full object hierarchy, i.e. it needs to start
     /// from the root! It leaves out irrelevant attributes, however (`parent_attribute`
     /// and `child.other_attribute`).
     pub fn json_body_partial<S: Into<String>>(mut self, partial: S) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! [MockServer::start](struct.MockServer.html#method.start)) while the server pool is empty
 //! (i.e. all servers are occupied by other tests).
 //!
-//! [MockServer](struct.MockServer.html)s are never recreated but recycled/resetted.
+//! [MockServer](struct.MockServer.html)s are never recreated but recycled/reset.
 //! The pool is filled on demand up to a maximum number of 25 servers.
 //! You can override this number by using the environment variable `HTTPMOCK_MAX_SERVERS`.
 //!

--- a/tests/resources/static_yaml_mock.yaml
+++ b/tests/resources/static_yaml_mock.yaml
@@ -28,7 +28,7 @@ when:
     this is a multiline
     example body string
     where linebreaks
-    DO NOT ADDITIONALY
+    DO NOT ADDITIONALLY
     ADD SPACE CHACATERS
     and INDENTATION IS
     IGNORED as with


### PR DESCRIPTION
Found via these commands:

    codespell . -L crate,ser,mot
    markdownlint *.md --disable md013 md033 md041