### PR TITLE
feat: allow user to specify shutdown signal

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -6,6 +6,7 @@ use crate::server::{start_server, MockServerState};
 use crate::Mock;
 use async_object_pool::Pool;
 use std::cell::Cell;
+use std::future::pending;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -277,7 +278,7 @@ const LOCAL_SERVER_ADAPTER_GENERATOR: fn() -> Arc<dyn MockServerAdapter + Send +
 
     thread::spawn(move || {
         let server_state = server_state.clone();
-        let srv = start_server(0, false, &server_state, Some(addr_sender), false);
+        let srv = start_server(0, false, &server_state, Some(addr_sender), false, pending());
 
         let mut runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,34 @@ async fn main() {
         params.mock_files_dir,
         !params.disable_access_log,
         params.request_history_limit,
+        shutdown_signal()
     )
     .await
     .expect("an error occurred during mock server execution");
 }
+
+#[cfg(not(target_os = "windows"))]
+async fn shutdown_signal() {
+    let mut hangup_stream = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+        .expect("Cannot install SIGINT signal handler");
+    let mut sigint_stream =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .expect("Cannot install SIGINT signal handler");
+    let mut sigterm_stream =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("Cannot install SIGINT signal handler");
+
+    tokio::select! {
+        _val = hangup_stream.recv() => log::trace!("Received SIGINT"),
+        _val = sigint_stream.recv() => log::trace!("Received SIGINT"),
+        _val = sigterm_stream.recv() => log::trace!("Received SIGTERM"),
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("Cannot install CTRL+C signal handler");
+}
+

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -20,7 +20,7 @@ pub fn simulate_standalone_server() {
 
 lazy_static! {
     static ref STANDALONE_SERVER: Mutex<JoinHandle<Result<(), String>>> = Mutex::new(spawn(|| {
-        let srv = start_standalone_server(5000, false, None, false, usize::MAX);
+        let srv = start_standalone_server(5000, false, None, false, usize::MAX, std::future::pending());
         let mut runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()


### PR DESCRIPTION
Thanks for the crate :) 

When using it as a library, ctrl+c/SIGHUP has no effect because it is handled here. The mockserver exiting does not necessarily mean our application should end (using this as part of cucumber tests). This PR allows the user to specify their own shutdown signal / std::futures::pending if not needed. Moved the handlers to the main when running standalone.