### PR TITLE
remove deprecated & unused `regex::internal::Input`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -16,7 +16,6 @@ use hyper::{
     Body, HeaderMap, Request as HyperRequest, Response as HyperResponse, Result as HyperResult,
     Server, StatusCode,
 };
-use regex::internal::Input;
 use regex::Regex;
 
 use matchers::generic::SingleValueMatcher;


### PR DESCRIPTION
Fixes #84.

PS: You can add `#[warn(unused)]` & then run `cargo clippy --fix` to automatically remove many other unused imports as well. I'm not doing it here since this is breaking our CI, so we need a quick fix first.