### PR TITLE
Clarify query_param doc test

### DIFF
--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -178,12 +178,12 @@ impl When {
     /// let server = MockServer::start();
     ///
     /// let m = server.mock(|when, then|{
-    ///     when.query_param("query", "Metallica");
+    ///     when.query_param("query", "Metallica is cool");
     ///     then.status(200);
     /// });
     ///
     /// // Act
-    /// get(server.url("/search?query=Metallica")).unwrap();
+    /// get(server.url("/search?query=Metallica+is+cool")).unwrap();
     ///
     /// // Assert
     /// m.assert();


### PR DESCRIPTION
I was using this library and ran into the exact problem from #56, but it still took me a moment and a bit of confusion to figure out exactly what I needed to do to make things work correctly. 

I realize that the [docs](https://docs.rs/httpmock/0.6.8/httpmock/struct.When.html#method.query_param) attempt to explain this issue with the following section:
> "Attention!: The request query keys and values are implicitly *allowed, but is not required*
> to be urlencoded! The value you pass here, however, must be in plain text (i.e. not encoded)!"

However, I think that the overall documentation would be more clear if the code showed an example of this as well, showing exactly what is explained above. 

I've updated the documentation to match example from issue #56.