### PR TITLE
feat: Add MockServer reset function

### DIFF
--- a/tests/examples/getting_started_tests.rs
+++ b/tests/examples/getting_started_tests.rs
@@ -50,3 +50,42 @@ async fn async_getting_started_test() {
     // Ensure the mock server did respond as specified above.
     assert_eq!(response.status(), 200);
 }
+
+#[async_std::test]
+async fn reset_test() {
+    // Start a lightweight mock server.
+    let server = MockServer::start();
+
+    // Create a mock on the server that will be reset later
+    server.mock(|when, then| {
+        when.method("GET")
+            .path("/translate")
+            .query_param("word", "hello");
+        then.status(500)
+            .header("content-type", "text/html; charset=UTF-8")
+            .body("Привет");
+    });
+
+    // Delete all previously created mocks
+    server.reset().await;
+
+    // Create a new mock that will replace the previous one
+    let hello_mock = server.mock(|when, then| {
+        when.method("GET")
+            .path("/translate")
+            .query_param("word", "hello");
+        then.status(200)
+            .header("content-type", "text/html; charset=UTF-8")
+            .body("Привет");
+    });
+
+    // Send an HTTP request to the mock server. This simulates your code.
+    let response = get(server.url("/translate?word=hello")).unwrap();
+
+    // Ensure the specified mock was called.
+    hello_mock.assert();
+
+    // Ensure the mock server did respond as specified.
+    assert_eq!(response.status(), 200);
+}
+


### PR DESCRIPTION
Sometimes it can be useful to change the behavior of the MockServer after some Mocks have already been setup.
This PR adds a `reset()` function to clear the existing `Mock`s and their recorded calls history.