### PR TITLE
Update base64 dependency to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_regex = "1.1"
 lazy_static = "1.4"
-base64 = "0.21"
+base64 = "0.22"
 regex = "1.10"
 log = "0.4"
 url = "2.4"


### PR DESCRIPTION
The changes in the `base64` seem unlikely to have a negative impact: [Changelog](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md)

I was running into problems updating base64 in my project - because I have a dependency on httpmock.
```
Command failed: cargo update --config net.git-fetch-with-cli=true --manifest-path mycrate/Cargo.toml --package base64@0.21.7 --precise 0.22.0
    Updating crates.io index
error: failed to select a version for the requirement `base64 = "^0.21"`
candidate versions found which didn't match: 0.22.0
location searched: crates.io index
required by package `ureq v2.9.6`
    ... which satisfies dependency `ureq = "^2.9.6"` (locked to 2.9.6) of package `mycrate v0.1.0 (/tmp/renovate/repos/path/mycrate)`
    ... which satisfies path dependency `mycrate` (locked to 0.1.0) of package `parentcrate v0.2.0+0 (/tmp/renovate/repos/path/parentcrate)`
perhaps a crate was updated and forgotten to be re-vendored?
```