### PR TITLE
Add delete_after_n method to When

### DIFF
--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -327,6 +327,40 @@ impl When {
         self
     }
 
+    /// Sets the number of requests the mock should respond to before self-destructing.
+    ///
+    /// * `count` - The number of requests to respond to.
+    ///
+    /// Note: the mock will no longer be available to assert against when the request
+    /// limit is hit.
+    ///
+    /// ```
+    /// use httpmock::prelude::*;
+    /// use isahc::{prelude::*, Request};
+    ///
+    /// let server = MockServer::start();
+    ///
+    /// let mock = server.mock(|when, then|{
+    ///     when.path("/test").delete_after_n(1);
+    ///     then.status(202);
+    /// });
+    ///
+    /// // Send a first request which deletes the mock from the server, then send another request.
+    /// let response1 = isahc::get(server.url("/test")).unwrap();
+    ///
+    /// let response2 = isahc::get(server.url("/test")).unwrap();
+    ///
+    /// // Assert
+    /// assert_eq!(response1.status(), 202);
+    /// assert_eq!(response2.status(), 404);
+    /// ```
+    pub fn delete_after_n(mut self, count: usize) -> Self {
+        update_cell(&self.expectations, |e| {
+            e.delete_after_n = Some(count);
+        });
+        self
+    }
+
     /// Sets the required HTTP request body content.
     ///
     /// * `body` - The required HTTP request body.

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -190,6 +190,7 @@ pub struct RequestRequirements {
     pub query_param: Option<Vec<(String, String)>>,
     pub x_www_form_urlencoded_key_exists: Option<Vec<String>>,
     pub x_www_form_urlencoded: Option<Vec<(String, String)>>,
+    pub delete_after_n: Option<usize>,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub matchers: Option<Vec<MockMatcherFunction>>,
@@ -221,6 +222,7 @@ impl RequestRequirements {
             query_param: None,
             x_www_form_urlencoded: None,
             x_www_form_urlencoded_key_exists: None,
+            delete_after_n: None,
             matchers: None,
         }
     }
@@ -297,6 +299,11 @@ impl RequestRequirements {
 
     pub fn with_query_param(mut self, arg: Vec<(String, String)>) -> Self {
         self.query_param = Some(arg);
+        self
+    }
+
+    pub fn with_delete_after_n(mut self, arg: usize) -> Self {
+        self.delete_after_n = Some(arg);
         self
     }
 }

--- a/src/standalone.rs
+++ b/src/standalone.rs
@@ -42,6 +42,7 @@ struct YAMLRequestRequirements {
     pub query_param: Option<Vec<NameValuePair>>,
     pub x_www_form_urlencoded_key_exists: Option<Vec<String>>,
     pub x_www_form_urlencoded_tuple: Option<Vec<NameValuePair>>,
+    pub delete_after_n: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -131,6 +132,7 @@ fn map_to_mock_definition(yaml_definition: YAMLMockDefinition) -> MockDefinition
             query_param: to_pair_vec(yaml_definition.when.query_param),
             x_www_form_urlencoded: to_pair_vec(yaml_definition.when.x_www_form_urlencoded_tuple),
             x_www_form_urlencoded_key_exists: yaml_definition.when.x_www_form_urlencoded_key_exists,
+            delete_after_n: yaml_definition.when.delete_after_n,
             matchers: None,
         },
         response: MockServerHttpResponse {


### PR DESCRIPTION
In situations where a component is expected to automatically retry an endpoint, manually calling `delete` on a `Mock` may not be an option.

To support this scenario, add a new `delete_after_n` method to `When` that will remove the `Mock` from the server after it has matched the specified number of calls.

Related to https://github.com/alexliesenfeld/httpmock/issues/76
Related to https://github.com/alexliesenfeld/httpmock/issues/96