### PR TITLE
Replace once_cell with std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ env_logger = { version = "0.11", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 async-std = { version = "1", features = ["attributes", "unstable"] }
 headers = { version = "0.4", optional = true }
-once_cell = "1"
 
 ### TLS / HTTPS / PROXY
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }


### PR DESCRIPTION
The `once_cell::sync::Lazy` functionality was made available in the `std` in Rust 1.80 via `std::sync::LazyLock`