### PR TITLE
Fix executor test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ tls-detect = { version = "0.1", optional = true }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "logging", "tls12", "native-tokio"], optional = true }
 futures-timer = "3"
 
-
 [dev-dependencies]
 env_logger = "0.11"
 actix-rt = "2"
@@ -60,7 +59,7 @@ reqwest = { version = "0.12", features = ["blocking", "cookies", "rustls-tls", "
 syn = { version = "2", features = ["full"] }
 urlencoding = "2"
 smol = "2"
-
+isahc = "1.7.2"
 
 [features]
 default = ["cookies"]

--- a/tests/misc/mod.rs
+++ b/tests/misc/mod.rs
@@ -2,5 +2,4 @@ mod extensions_test;
 #[cfg(feature = "remote")]
 mod large_body_test;
 mod loop_test;
-#[cfg(all(feature = "proxy", feature = "remote"))]
 mod runtimes_test;


### PR DESCRIPTION
This reorganizes test cases to support major async executors. 

At the moment, proxy does not work due to TLS issues, but this is not related to async executors.