### PR TITLE
Replace custom read_file with std::fs::read_to_string

### DIFF
--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -16,10 +16,7 @@ use crate::{
 #[cfg(feature = "proxy")]
 use crate::{
     api::proxy::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder},
-    common::{
-        data::{ForwardingRuleConfig, ProxyRuleConfig},
-        util::read_file,
-    },
+    common::data::{ForwardingRuleConfig, ProxyRuleConfig},
 };
 
 #[cfg(feature = "record")]
@@ -1178,19 +1175,17 @@ impl MockServer {
     /// This method is only available when the `record` feature is enabled.
     #[cfg(feature = "record")]
     pub async fn playback_async<IntoPathBuf: Into<PathBuf>>(&self, path: IntoPathBuf) -> MockSet {
+        use std::fs;
+
         let path = path.into();
-        let content = read_file(&path).expect(&format!(
+        let content = fs::read_to_string(&path).expect(&format!(
             "could not read from file {}",
             path.as_os_str()
                 .to_str()
                 .map_or(String::new(), |p| p.to_string())
         ));
 
-        return self
-            .playback_from_yaml_async(
-                String::from_utf8(content).expect("cannot convert file content to UTF-8"),
-            )
-            .await;
+        return self.playback_from_yaml_async(content).await;
     }
 
     /// Configures the mock server to respond with the recorded responses based on a provided recording

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
         data::{MockServerHttpResponse, RequestRequirements},
-        util::{get_test_resource_file_path, read_file, update_cell, HttpMockBytes},
+        util::{get_test_resource_file_path, update_cell, HttpMockBytes},
     },
     prelude::HttpMockRequest,
     Method, Regex,
@@ -10,7 +10,8 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    cell::Cell, convert::TryInto, path::Path, rc::Rc, str::FromStr, sync::Arc, time::Duration,
+    cell::Cell, convert::TryInto, fs::read_to_string, path::Path, rc::Rc, str::FromStr, sync::Arc,
+    time::Duration,
 };
 
 /// A function that encapsulates one or more
@@ -5067,7 +5068,7 @@ impl Then {
                 &resource_file_path
             )),
         };
-        let content = read_file(&absolute_path).expect(&format!(
+        let content = read_to_string(&absolute_path).expect(&format!(
             "Cannot read from file {}",
             absolute_path.to_str().expect("Invalid OS path")
         ));

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -102,28 +102,6 @@ pub fn get_test_resource_file_path(relative_resource_path: &str) -> Result<PathB
     }
 }
 
-pub fn read_file<P: AsRef<Path>>(absolute_resource_path: P) -> Result<Vec<u8>, String> {
-    let mut f = match File::open(&absolute_resource_path) {
-        Ok(mut opened_file) => opened_file,
-        Err(e) => return Err(e.to_string()),
-    };
-    let mut buffer = Vec::new();
-    match f.read_to_end(&mut buffer) {
-        Ok(len) => log::trace!(
-            "Read {} bytes from file {:?}",
-            &len,
-            &absolute_resource_path
-                .as_ref()
-                .as_os_str()
-                .to_str()
-                .expect("Invalid file path")
-        ),
-        Err(e) => return Err(e.to_string()),
-    }
-
-    Ok(buffer)
-}
-
 pub async fn write_file<P: AsRef<Path>>(
     resource_path: P,
     content: &Bytes,

--- a/src/server/persistence.rs
+++ b/src/server/persistence.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use std::{
     convert::{TryFrom, TryInto},
-    fs::read_dir,
+    fs::{read_dir, read_to_string},
     path::PathBuf,
     str::FromStr,
 };
@@ -13,10 +13,7 @@ use serde_yaml::{Deserializer, Value as YamlValue};
 use thiserror::Error;
 
 use crate::{
-    common::{
-        data::{MockDefinition, StaticMockDefinition},
-        util::read_file,
-    },
+    common::data::{MockDefinition, StaticMockDefinition},
     server::{
         persistence::Error::{DeserializationError, FileReadError},
         state,
@@ -66,8 +63,7 @@ fn read_static_mocks(path: PathBuf) -> Result<Vec<StaticMockDefinition>, Error> 
             file_path.to_string_lossy()
         );
 
-        let content = read_file(file_path).map_err(|err| FileReadError(err.to_string()))?;
-        let content = String::from_utf8(content).map_err(|err| FileReadError(err.to_string()))?;
+        let content = read_to_string(file_path).map_err(|err| FileReadError(err.to_string()))?;
 
         definitions.extend(deserialize_mock_defs_from_yaml(&content)?);
     }


### PR DESCRIPTION
Just a small thing i stumbled across while doing the log -> tracing migration